### PR TITLE
Add i386 and arm32v7 building and update to alpine 3.23.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,52 +3,73 @@ name: release
 on:
   push:
     tags: ["v*"]
-
+  workflow_dispatch:
+env:
+  ALPINE_VERSION: 3.23
 jobs:
   build-binaries:
-    runs-on: ${{ matrix.runner.label }}
     strategy:
+      fail-fast: false
       matrix:
+        arch: ["i386","amd64","arm32v7","arm64"]
         runner:
-          - { arch: amd64, label: ubuntu-24.04 }
-          - { arch: arm64, label: ubuntu-24.04-arm }
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        exclude:
+          - arch: amd64
+            runner: ubuntu-24.04-arm
+          - arch: i386
+            runner: ubuntu-24.04-arm
+          - arch: arm64
+            runner: ubuntu-24.04
+          - arch: arm32v7
+            runner: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
-
-      - run: docker build -o=dist community/fio
-      - run: docker build -o=dist community/libqrencode
-      - run: docker build -o=dist community/redis
-      - run: docker build -o=dist main/7zip
-      - run: docker build -o=dist main/curl
-      - run: docker build -o=dist main/htop
-      - run: docker build -o=dist main/iperf3
-      - run: docker build -o=dist main/iproute2
-      - run: docker build -o=dist main/lsof
-      - run: docker build -o=dist main/mariadb
-      - run: docker build -o=dist main/nano
-      - run: docker build -o=dist main/netcat-openbsd
-      - run: docker build -o=dist main/nmap
-      - run: docker build -o=dist main/pigz
-      - run: docker build -o=dist main/postgresql17
-      - run: docker build -o=dist main/procps-ng
-      - run: docker build -o=dist main/rsync
-      - run: docker build -o=dist main/socat
-      - run: docker build -o=dist main/strace
-      - run: docker build -o=dist main/tcpdump
-      - run: docker build -o=dist main/vim
-      - run: docker build -o=dist main/wget
-      - run: docker build -o=dist custom/mysql57
-      - run: docker build -o=dist custom/mysql80
-      - run: docker build -o=dist custom/mysql84
+      - uses: actions/checkout@v6
+      - name: Set build variables
+        id: set-build-variables
+        run: |
+          BUILDARCH="$(echo ${{ matrix.arch }} | sed 's,arm64,arm64v8,')"
+          export BUILDARCH
+          echo "BUILDARCH=${BUILDARCH}" >> "$GITHUB_ENV"
+          DOCKER_DEFAULT_PLATFORM="linux/$(echo ${{ matrix.arch }} | sed 's,arm32v7,arm/v7,')"
+          export DOCKER_DEFAULT_PLATFORM
+          echo "DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM}" >> "$GITHUB_ENV"
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist community/fio
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist community/libqrencode
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist community/redis
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/7zip
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/curl
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/htop
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/iperf3
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/iproute2
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/lsof
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/mariadb
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/nano
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/netcat-openbsd
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/nmap
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/pigz
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/postgresql17
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/procps-ng
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/rsync
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/socat
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/strace
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/tcpdump
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/vim
+      - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist main/wget
+      # - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist custom/mysql57
+      # - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist custom/mysql80
+      # - run: docker build --build-arg BUILDARCH="${BUILDARCH}" --build-arg ALPINE_VERSION="${ALPINE_VERSION}" -o=dist custom/mysql84
 
       - run: |
           for file in dist/*; do
-            mv "$file" "${file}_${GITHUB_REF_NAME}_linux_${{ matrix.runner.arch }}"
+            mv "$file" "${file}_${GITHUB_REF_NAME}_linux_${{ matrix.arch }}"
           done
 
       - uses: actions/upload-artifact@v4
         with:
-          name: static-binaries-artifact-${{ matrix.runner.arch }}
+          name: static-binaries-artifact-${{ matrix.arch }}
           path: dist/*
           retention-days: 1
           if-no-files-found: error

--- a/community/fio/Dockerfile
+++ b/community/fio/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=community/fio
 ARG PACKAGE_NAME=fio
 ARG PACKAGE_VERSION=3.39
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -46,7 +47,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/fio" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/fio" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/fio" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/fio" -o /usr/local/bin/fio
 
 # STEP-4: export executable

--- a/community/libqrencode/Dockerfile
+++ b/community/libqrencode/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=community/libqrencode
 ARG PACKAGE_NAME=libqrencode
 ARG PACKAGE_VERSION=4.1.1
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -50,7 +51,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/qrencode" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/qrencode" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/qrencode" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/qrencode" -o /usr/local/bin/qrencode
 
 # STEP-4: export executable

--- a/community/redis/Dockerfile
+++ b/community/redis/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=community/redis
 ARG PACKAGE_NAME=redis
 ARG PACKAGE_VERSION=8.0.4
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -55,7 +56,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/redis-cli" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/redis-cli" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/redis-cli" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/redis-cli" -o /usr/local/bin/redis-cli
 
 # STEP-4: export executable

--- a/custom/mysql57/Dockerfile
+++ b/custom/mysql57/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=custom/mysql57
 ARG PACKAGE_NAME=mysql57
 ARG PACKAGE_VERSION=5.7.44
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -38,10 +39,10 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" -o /usr/local/bin/mysql57 && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" -o /usr/local/bin/mysqldump57
 
 # STEP-4: export executable

--- a/custom/mysql57/aports/APKBUILD
+++ b/custom/mysql57/aports/APKBUILD
@@ -11,7 +11,7 @@ pkggroups="mysql"
 arch="x86_64 aarch64"
 license="GPL"
 _boost_ver=1.59.0
-makedepends="bison cmake linux-headers libaio-dev ncurses-dev openssl-dev zlib-dev ncurses-static openssl-libs-static zlib-static"
+makedepends="bison cmake linux-headers libaio-dev ninja ncurses-dev openssl-dev zlib-dev ncurses-static openssl-libs-static zlib-static"
 source="https://dev.mysql.com/get/Downloads/MySQL-5.7/$_pkgname-$pkgver.tar.gz
 	https://archives.boost.io/release/$_boost_ver/source/boost_${_boost_ver//./_}.tar.gz
 	strerror.patch
@@ -29,6 +29,7 @@ build() {
 		-DBUILD_CONFIG=mysql_release \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		-DCOMPILATION_COMMENT="Alpine Linux" \
 		-DSYSCONFDIR=/etc/mysql \
 		-DMYSQL_DATADIR=/var/lib/mysql \

--- a/custom/mysql80/Dockerfile
+++ b/custom/mysql80/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=custom/mysql80
 ARG PACKAGE_NAME=mysql80
 ARG PACKAGE_VERSION=8.0.42
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -38,10 +39,10 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" -o /usr/local/bin/mysql80 && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" -o /usr/local/bin/mysqldump80
 
 # STEP-4: export executable

--- a/custom/mysql84/Dockerfile
+++ b/custom/mysql84/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=custom/mysql84
 ARG PACKAGE_NAME=mysql84
 ARG PACKAGE_VERSION=8.4.5
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -38,10 +39,10 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysql" -o /usr/local/bin/mysql84 && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mysqldump" -o /usr/local/bin/mysqldump84
 
 # STEP-4: export executable

--- a/main/7zip/Dockerfile
+++ b/main/7zip/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/7zip
 ARG PACKAGE_NAME=7zip
 ARG PACKAGE_VERSION=24.09
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -45,7 +46,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/7zz" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/7zz" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/7zz" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/7zz" -o /usr/local/bin/7z
 
 # STEP-4: export executable

--- a/main/curl/Dockerfile
+++ b/main/curl/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/curl
 ARG PACKAGE_NAME=curl
 ARG PACKAGE_VERSION=8.14.1
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -62,7 +63,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/curl" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/curl" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/curl" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/curl" -o /usr/local/bin/curl
 
 # STEP-4: export executable

--- a/main/htop/Dockerfile
+++ b/main/htop/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/htop
 ARG PACKAGE_NAME=htop
 ARG PACKAGE_VERSION=3.4.1
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -44,7 +45,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/htop" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/htop" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/htop" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/htop" -o /usr/local/bin/htop
 
 # STEP-4: export executable

--- a/main/iperf3/Dockerfile
+++ b/main/iperf3/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/iperf3
 ARG PACKAGE_NAME=iperf3
 ARG PACKAGE_VERSION=3.19.1
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -44,7 +45,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/iperf3" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/iperf3" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/iperf3" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/iperf3" -o /usr/local/bin/iperf3
 
 # STEP-4: export executable

--- a/main/iproute2/Dockerfile
+++ b/main/iproute2/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/iproute2
 ARG PACKAGE_NAME=iproute2
 ARG PACKAGE_VERSION=6.15.0
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -51,7 +52,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/sbin/ss" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/sbin/ss" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/sbin/ss" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/sbin/ss" -o /usr/local/bin/ss
 
 # STEP-4: export executable

--- a/main/lsof/Dockerfile
+++ b/main/lsof/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/lsof
 ARG PACKAGE_NAME=lsof
 ARG PACKAGE_VERSION=4.99.4
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -43,7 +44,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/lsof" -h && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/lsof" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/lsof" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/lsof" -o /usr/local/bin/lsof
 
 # STEP-4: export executable

--- a/main/mariadb/Dockerfile
+++ b/main/mariadb/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/mariadb
 ARG PACKAGE_NAME=mariadb
 ARG PACKAGE_VERSION=11.4.8
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -71,10 +72,10 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb" -o /usr/local/bin/mariadb && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb-dump" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb-dump" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb-dump" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/mariadb-dump" -o /usr/local/bin/mariadb-dump
 
 # STEP-4: export executable

--- a/main/nano/Dockerfile
+++ b/main/nano/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/nano
 ARG PACKAGE_NAME=nano
 ARG PACKAGE_VERSION=8.4
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -44,7 +45,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nano" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nano" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nano" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nano" -o /usr/local/bin/nano
 
 # STEP-4: export executable

--- a/main/netcat-openbsd/Dockerfile
+++ b/main/netcat-openbsd/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/netcat-openbsd
 ARG PACKAGE_NAME=netcat-openbsd
 ARG PACKAGE_VERSION=1.229-1
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -44,7 +45,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nc" -h && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nc" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nc" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nc" -o /usr/local/bin/nc
 
 # STEP-4: export executable

--- a/main/nmap/Dockerfile
+++ b/main/nmap/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/nmap
 ARG PACKAGE_NAME=nmap
 ARG PACKAGE_VERSION=7.97
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -52,7 +53,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nmap" -h && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nmap" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nmap" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/nmap" -o /usr/local/bin/nmap
 
 # STEP-4: export executable

--- a/main/pigz/Dockerfile
+++ b/main/pigz/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/pigz
 ARG PACKAGE_NAME=pigz
 ARG PACKAGE_VERSION=2.8
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -44,7 +45,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/pigz" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/pigz" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/pigz" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/pigz" -o /usr/local/bin/pigz
 
 # STEP-4: export executable

--- a/main/postgresql17/Dockerfile
+++ b/main/postgresql17/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/postgresql17
 ARG PACKAGE_NAME=postgresql17
 ARG PACKAGE_VERSION=17.6
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -73,10 +74,10 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/psql" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/psql" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/psql" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/psql" -o /usr/local/bin/psql && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/pg_dump" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/pg_dump" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/pg_dump" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/libexec/${PACKAGE_NAME}/pg_dump" -o /usr/local/bin/pg_dump
 
 # STEP-4: export executable

--- a/main/procps-ng/Dockerfile
+++ b/main/procps-ng/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/procps-ng
 ARG PACKAGE_NAME=procps-ng
 ARG PACKAGE_VERSION=4.0.4
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -48,7 +49,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/bin/ps" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/bin/ps" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/bin/ps" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/bin/ps" -o /usr/local/bin/ps
 
 # STEP-4: export executable

--- a/main/rsync/Dockerfile
+++ b/main/rsync/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/rsync
 ARG PACKAGE_NAME=rsync
 ARG PACKAGE_VERSION=3.4.1
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -68,7 +69,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/rsync" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/rsync" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/rsync" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/rsync" -o /usr/local/bin/rsync
 
 # STEP-6: export executable

--- a/main/socat/Dockerfile
+++ b/main/socat/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/socat
 ARG PACKAGE_NAME=socat
 ARG PACKAGE_VERSION=1.8.0.3
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -46,7 +47,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/socat1" -h && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/socat1" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/socat1" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/socat1" -o /usr/local/bin/socat
 
 # STEP-4: export executable

--- a/main/strace/Dockerfile
+++ b/main/strace/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/strace
 ARG PACKAGE_NAME=strace
 ARG PACKAGE_VERSION=6.13
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -44,7 +45,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/strace" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/strace" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/strace" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/strace" -o /usr/local/bin/strace
 
 # STEP-4: export executable

--- a/main/tcpdump/Dockerfile
+++ b/main/tcpdump/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/tcpdump
 ARG PACKAGE_NAME=tcpdump
 ARG PACKAGE_VERSION=4.99.5
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -51,7 +52,7 @@ RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/tcpdump" -h && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/tcpdump" -D && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/tcpdump" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/tcpdump" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/tcpdump" -o /usr/local/bin/tcpdump
 
 # STEP-4: export executable

--- a/main/vim/Dockerfile
+++ b/main/vim/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/vim
 ARG PACKAGE_NAME=vim
 ARG PACKAGE_VERSION=9.1.1566
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -49,10 +50,10 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/vim" -h && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/vim" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/vim" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/vim" -o /usr/local/bin/vim && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/xxd" -v && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/xxd" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/xxd" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/xxd" -o /usr/local/bin/xxd
 
 # STEP-4: export executable

--- a/main/wget/Dockerfile
+++ b/main/wget/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1.16
 # https://docs.docker.com/build/dockerfile/frontend/
 
-ARG ALPINE_VERSION=3.22
+ARG BUILDARCH=amd64
+ARG ALPINE_VERSION=3.23
 ARG PACKAGE_PATH=main/wget
 ARG PACKAGE_NAME=wget
 ARG PACKAGE_VERSION=1.25.0
 
-FROM docker.io/library/alpine:${ALPINE_VERSION} AS build
+FROM ${BUILDARCH}/alpine:${ALPINE_VERSION} AS build
 
 # redeclare in build stage to inherit arguments from global scope
 # https://docs.docker.com/build/building/variables/#scoping
@@ -51,7 +52,7 @@ EOT
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$BUILDARCH,sharing=locked \
   cd "${PACKAGE_PATH}" && apk del ${EXTRA_DEPS} && abuild -F undeps && \
   "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/wget" --help && \
-  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/wget" | grep -q 'statically linked' && \
+  file "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/wget" | grep -q 'static-pie linked\|statically linked' && \
   strip "/src/${PACKAGE_PATH}/pkg/${PACKAGE_NAME}/usr/bin/wget" -o /usr/local/bin/wget
 
 # STEP-4: export executable


### PR DESCRIPTION
- Add alpine architecture image selection using the `BUILDARCH` variable in Dockerfiles.
- Update workflow to generate builds for i386 and arm32v7, though there's no reason this couldn't be expanded to all alpine architectures.
- Fix `file <binary>` check to also search for `static-pie linked` string.
- Add `workflow_dispatch` trigger to workflow.
- Move `ALPINE_VERSION` to workflow.
- Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 & ninja to mysql57. (Though this didn't fix the build.)
- Disable the mysql builds. which are broken.

- This does build on my end (using the workflow dispatch), aside from the last step which needs a tag first.
<img width="2721" height="1518" alt="image" src="https://github.com/user-attachments/assets/bb6a034d-056f-4a25-88a1-bc6c8881cee2" />
